### PR TITLE
uncomment '+' from cookielite

### DIFF
--- a/src/cookie-lite.coffee
+++ b/src/cookie-lite.coffee
@@ -3,7 +3,7 @@ CookieLite = (name, value, opts) ->
 	if arguments.length > 1
 		str = name + "=" + escape(value) +
 			(if opts.ttl? then "; expires=" + new Date(+new Date()+(1e3*opts.ttl)).toUTCString() else "") +
-			(if opts.path? then "; path=" + opts.path else "") # +
+			(if opts.path? then "; path=" + opts.path else "") +
 			(if opts.domain? then "; domain=" + opts.domain else "") +
 			(if opts.secure? then "; secure" else "")
 		return document.cookie = str


### PR DESCRIPTION
Was this meant to be commented out? It was throwing jshint errors in the build. 
